### PR TITLE
chore: externalize react runtime

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
     dts: true,
     clean: true,
     target: "esnext",
+    external: ["react/jsx-runtime", "react/jsx-dev-runtime"],
   },
   {
     entry: {
@@ -18,5 +19,6 @@ export default defineConfig([
     dts: true,
     clean: false,
     target: "esnext",
+    external: ["react/jsx-runtime", "react/jsx-dev-runtime"],
   },
 ]);


### PR DESCRIPTION
## Summary
- exclude `react/jsx-runtime` and `react/jsx-dev-runtime` from bundles

## Testing
- `npm run build`
- `npm publish --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0c46cd4832b83bf2e2b2569c00f